### PR TITLE
Use the runtime `sampleRate` from the audioContext

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ const TIMIDITY_CFG = fs.readFileSync(
   'utf8'
 )
 
-const SAMPLE_RATE = 44100
+const DEFAULT_SAMPLE_RATE = 44100 // the audioContext.sampleRate will override this
 const AUDIO_FORMAT = 0x8010 // format of the rendered audio 's16'
 const NUM_CHANNELS = 2 // stereo (2 channels)
 const BYTES_PER_SAMPLE = 2 * NUM_CHANNELS
@@ -162,7 +162,7 @@ class Timidity extends EventEmitter {
 
   _loadSong (midiBuf) {
     const optsPtr = this._lib._mid_alloc_options(
-      SAMPLE_RATE,
+      this._audioContext.sampleRate || DEFAULT_SAMPLE_RATE,
       AUDIO_FORMAT,
       NUM_CHANNELS,
       BUFFER_SIZE


### PR DESCRIPTION
This fixes a problem (#14) on some platforms that use a sample
rate of 48000, which results in faster, higher pitch play
back.