### PR TITLE
Add render() method to get raw sample data.

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,23 @@ just call `player.pause()` to pause or `player.load()` to load a new MIDI file.
 Returns `true` if `destroy()` has been called on the player. Returns `false`
 otherwise.
 
+### `player.render()`
+
+Renders the loaded MIDI file to audio data. Returns an array of `Float32Array`s
+containing the raw left and right sample data for the entire song. The
+`render()` method should only be called once the MIDI file and soundfonts have
+been loaded:
+
+```
+player.on("loaded", function() {
+  const arrays = player.render()
+  console.log(arrays)
+})
+```
+
+Note: the uncompressed sample data can consume a lot of memory, depending on
+the length of the song.
+
 ### `player.on('error', (err) => {})`
 
 This event fires if a fatal error occurs in the player, including if a MIDI file

--- a/index.js
+++ b/index.js
@@ -148,7 +148,7 @@ class Timidity extends EventEmitter {
     this._songPtr = songPtr
     this._lib._mid_song_start(this._songPtr)
     debugVerbose('Song and instruments are loaded')
-    this.emit("loaded")
+    this.emit('loaded')
   }
 
   _getMissingInstruments (songPtr, missingCount) {
@@ -285,7 +285,7 @@ class Timidity extends EventEmitter {
           arrays[1][i + lastSample] = _array[i * 2 + 1] / 0x7FFF
         }
         lastSample = lastSample + sampleCount
-        this.emit("progress", lastSample, buffSize);
+        this.emit('progress', lastSample, buffSize)
       }
     }
 
@@ -294,7 +294,7 @@ class Timidity extends EventEmitter {
     this.pause()
     this._lib._mid_song_start(this._songPtr)
 
-    return arrays;
+    return arrays
   }
 
   _onAudioProcess (event) {


### PR DESCRIPTION
Hi @feross, thanks for this wonderful library which I'm using over at https://dopeloop.ai/melody-generator. For a different application I wanted to be able to get the raw audio samples of the rendered MIDI file, and this patch adds that functionality with the `render()` method. It returns a pair of `Float32Array`s containing the left and right channel audio data, which can then be used to mix with other audio, compress to mp3, or whatever. I also updated the documentation. I know you are super busy, so thank you for considering this PR for merging. :pray:

Here is some test code for trying out the `render()` method:

```
const Timidity = require('timidity')

const player = new Timidity()

player.load('/pachelbel_canon.mid')

player.on("progress", function(value, total) {
  console.log("progress", value, "/", total)
});

player.on("loaded", function() {
  console.log("duration:", player.duration)
  console.log("song:", player._currentUrlOrBuf)
  const arrays = player.render()
  console.log(arrays)

  var audioCtx = new (window.AudioContext || window.webkitAudioContext)();
  var myArrayBuffer = audioCtx.createBuffer(2, arrays[0].length, audioCtx.sampleRate);
  for (var channel = 0; channel < myArrayBuffer.numberOfChannels; channel++) {
    myArrayBuffer.copyToChannel(arrays[channel], channel)
  }
  var source = audioCtx.createBufferSource();
  source.buffer = myArrayBuffer;
  source.connect(audioCtx.destination);
  source.start();
})
```